### PR TITLE
Add key for zooming in and out

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -68,6 +68,7 @@ config.keys = {
       act.SendKey { key = 'L', mods = 'CTRL' }
     }
   },
+  { key = 'z', mods = 'CTRL', action = act.TogglePaneZoomState },
   { key = 'r', mods = 'LEADER', action = act.ActivateKeyTable { name = 'resize_pane', one_shot = false, }, },
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to dot-github! Please replace {Please write here} with your description -->

# What was a problem / Description ?

Lack of key for zooming in and our

## How this PR fixes the problem?

Adds key in the wezterm.lua for zooming in and out

